### PR TITLE
remove extra trailing character, add OSX build options

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,5 @@
+PLATFORM=$(shell uname -s)
+
 GPP=$(CXX)
 CPPFLAGS=-Wall -Wextra -std=c++17 -O3 -g -Izstr/src -Iparallel-hashmap/parallel_hashmap/ -Icxxopts/include -Wno-unused-parameter `pkg-config --cflags zlib` -IMBG/src -Iconcurrentqueue
 
@@ -14,7 +16,13 @@ DEPS = $(patsubst %, $(SRCDIR)/%, $(_DEPS))
 _OBJ = MatchIndex.o MinimizerIterator.o TwobitString.o ReadStorage.o UnitigKmerCorrector.o UnitigStorage.o ReadMatchposStorage.o
 OBJ = $(patsubst %, $(ODIR)/%, $(_OBJ))
 
-LINKFLAGS = $(CPPFLAGS) -Wl,-Bstatic $(LIBS) -Wl,-Bdynamic -Wl,--as-needed -lpthread -pthread -static-libstdc++
+
+ifeq ($(PLATFORM),Linux)
+   LINKFLAGS = $(CPPFLAGS) -Wl,-Bstatic $(LIBS) -Wl,-Bdynamic -Wl,--as-needed -lpthread -pthread -static-libstdc++
+else
+   CPPFLAGS += -D_LIBCPP_DISABLE_AVAILABILITY
+   LINKFLAGS = $(CPPFLAGS) $(LIBS) -lpthread -pthread -static-libstdc++
+endif
 
 VERSION := Branch $(shell git rev-parse --abbrev-ref HEAD) commit $(shell git rev-parse HEAD) $(shell git show -s --format=%ci)
 


### PR DESCRIPTION
Add the same options as MBG for building on OSX (-D_LIBCPP_DISABLE_AVAILABILITY) so we don't have to always do it in conda recipes. Also removed ^M that was showing up on my linux system using dos2unix.